### PR TITLE
SDK-273 Disable error collection

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -12,14 +12,16 @@ This package provides tracing to front end of web applications for the collectio
 
 ## Contents
 
-- [Installation](#installation)
-- [Usage](#usage)
+- [Epsagon Tracing for Web](#epsagon-tracing-for-web)
+  - [Contents](#contents)
+  - [Installation](#installation)
+  - [Usage](#usage)
   - [Custom Tags](#custom-tags)
-- [Configuration](#configuration)
-  - [Trace Header Propagation](#trace-header-propagation)
-- [Getting Help](#getting-help)
-- [Opening Issues](#opening-issues)
-- [License](#license)
+  - [Configuration](#configuration)
+    - [Trace Header Propagation](#trace-header-propagation)
+  - [Getting Help](#getting-help)
+  - [Opening Issues](#opening-issues)
+  - [License](#license)
 
 ## Installation
 
@@ -49,10 +51,10 @@ Options for ```epsagon.identify``` include { userId, userName, userEmail, compan
 
 ```js
 epsagon.identify({
-  userId: '7128f1a08a95e46c', 
-  userName: 'John Doe', 
+  userId: '7128f1a08a95e46c',
+  userName: 'John Doe',
   userEmail: 'john@doe.com',
-  companyId: 'fcffa7328813e4', 
+  companyId: 'fcffa7328813e4',
   companyName: 'Epsagon'
 })
 
@@ -79,6 +81,7 @@ Advanced options can be configured as a parameter to the init() method.
 |isEpsagonDisabled       |Boolean|`false`       |A flag to completely disable Epsagon (can be used for tests or locally)         |
 |epsagonDebug       |Boolean|`false`       |Enable debug prints for troubleshooting. Note: if this flag is true, this will override the logLevel|
 |logLevel       |String|`INFO`       |The default Log level. Could be one of: ```DEBUG```, ```INFO```, ```WARN```, ```ERROR```, ```ALL```.|
+|errorDisabled      |Boolean|`false`      |Disables collection of errors while still sending traces                             |
 
 
 ### Trace Header Propagation
@@ -91,7 +94,7 @@ epsagon.init({
   token: 'epsagon-token',
   appName: 'app-name-stage',
   propagateTraceHeaderUrls: ['localhost', 'sub.example.com'],
-  urlPatternsToIgnore: [".*example.*", ".*abc.*"]  
+  urlPatternsToIgnore: [".*example.*", ".*abc.*"]
 })
 ```
 

--- a/packages/web/src/instrumentation/documentLoadInstrumentation.js
+++ b/packages/web/src/instrumentation/documentLoadInstrumentation.js
@@ -7,9 +7,10 @@ import EpsagonUtils from '../utils';
 const api = require('@opentelemetry/api');
 
 class EpsagonDocumentLoadInstrumentation extends DocumentLoadInstrumentation {
-  constructor(parentSpan) {
+  constructor(parentSpan, isErrorCollectionDisabled) {
     super();
     this.epsParentSpan = parentSpan;
+    this.isErrorCollectionDisabled = isErrorCollectionDisabled;
   }
 
   _onDocumentLoaded(event = false) {
@@ -17,7 +18,8 @@ class EpsagonDocumentLoadInstrumentation extends DocumentLoadInstrumentation {
     // Support for event "loadend" is very limited and cannot be used
     /* eslint-disable no-undef */
     window.setTimeout(() => {
-      if (event.error || event.reason) {
+      if ((event.error || event.reason) && !this.isErrorCollectionDisabled) {
+      // if (event.error || event.reason) {
         this.reportError(event);
       } else {
         this._collectPerformance();

--- a/packages/web/src/web-tracer.js
+++ b/packages/web/src/web-tracer.js
@@ -90,7 +90,7 @@ function handleLogLevel(_logLevel) {
     case 'ERROR':
       logLevel = DiagLogLevel.ERROR;
       break;
-      // Default is Open Telemetry default which is DiagLogLevel.INFO
+    // Default is Open Telemetry default which is DiagLogLevel.INFO
     default:
       return;
   }
@@ -207,10 +207,12 @@ function init(_configData) {
     });
   }
 
+  const isErrorCollectionDisabled = _configData.errorDisabled ? _configData.errorDisabled : false;
+
   registerInstrumentations({
     tracerProvider: provider,
     instrumentations: [
-      new EpsagonDocumentLoadInstrumentation(epsSpan),
+      new EpsagonDocumentLoadInstrumentation(epsSpan, isErrorCollectionDisabled),
       new EpsagonFetchInstrumentation({
         ignoreUrls: blackListedURLs,
         propagateTraceHeaderCorsUrls: whiteListedURLsRegex,
@@ -220,7 +222,7 @@ function init(_configData) {
         propagateTraceHeaderCorsUrls: whiteListedURLsRegex,
       }, epsSpan, { metadataOnly: configData.metadataOnly }),
       new EpsagonRedirectInstrumentation(tracer, epsSpan, DEFAULT_CONFIGURATIONS.redirectTimeout),
-    ],
+    ]
   });
 
   return { tracer, epsSpan };

--- a/packages/web/test/disabled-error-collection.test.js
+++ b/packages/web/test/disabled-error-collection.test.js
@@ -1,0 +1,34 @@
+import EpsagonDocumentLoadInstrumentation from '../src/instrumentation/documentLoadInstrumentation';
+
+const chai = require('chai');
+const sinon = require('sinon');
+const helper = require('./helper');
+const epsagon = require('../src/web-tracer');
+
+const sandbox = sinon.createSandbox();
+let spyCreateSpan;
+
+describe('Error Collection', () => {
+  beforeEach(() => {
+    helper.browserenv({errorDisabled: true});
+    spyCreateSpan = sandbox.spy(EpsagonDocumentLoadInstrumentation.prototype, 'reportError');
+
+    Object.defineProperty(global.window.document, 'readyState', {
+      writable: true,
+      value: 'complete',
+    });
+  });
+
+  afterEach(() => {
+    spyCreateSpan.restore();
+  });
+
+  it('should not create a span for a raised error', (done) => {
+    epsagon.init({isTest: true, token: 'abcdef', errorDisabled: true})
+    helper.createError();
+    setTimeout(() => {
+      chai.expect(spyCreateSpan.callCount).to.equal(0);
+      done();
+    }, 0);
+  });
+});

--- a/packages/web/test/docLoad.test.js
+++ b/packages/web/test/docLoad.test.js
@@ -6,7 +6,6 @@ const chai = require('chai');
 const sinon = require('sinon');
 const helper = require('./helper');
 
-helper.browserenv();
 const sandbox = sinon.createSandbox();
 
 const entries = {
@@ -35,6 +34,10 @@ const entries = {
 let spyEntries;
 let spyExporter;
 describe('docload instrumentation', () => {
+  before(() => {
+    helper.browserenv({errorDisabled: false});
+  });
+
   beforeEach(() => {
     Object.defineProperty(global.window.document, 'readyState', {
       writable: true,

--- a/packages/web/test/helper.js
+++ b/packages/web/test/helper.js
@@ -11,10 +11,14 @@ class Request {
   }
 }
 
+const defaults = {
+  errorDisabled: false
+};
+
 /**
  *  Simulate browser environment for nodejs.
  */
-module.exports.browserenv = function () {
+module.exports.browserenv = function (options = defaults) {
   const cfg = { url: 'http://localhost' };
   const dom = new JSDOM('', cfg);
   global.window = dom.window;
@@ -55,7 +59,12 @@ module.exports.browserenv = function () {
 
   globalThis.Request = Request;
 
-  const res = epsagon.init({ token: 'dfsaf', isTest: true });
+  let initArgs = {
+    ...{ token: 'dfsaf', isTest: true },
+    ...options
+  };
+
+  const res = epsagon.init(initArgs);
   return res.epsSpan;
 };
 

--- a/packages/web/test/web-tracer.test.js
+++ b/packages/web/test/web-tracer.test.js
@@ -8,6 +8,12 @@ before(helper.browserenv);
 const appName = 'test app';
 
 describe('init tests', () => {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
   it('init function exists', (done) => {
     chai.expect(typeof epsagon.init === 'function').to.equal(true);
     done();


### PR DESCRIPTION
This PR introduces a new flag that allows a user to disable error collection while still sending traces to Epsagon. 